### PR TITLE
Strip whitespace of starting HTML in acceptance test

### DIFF
--- a/acceptance_test/ruby/Gemfile.lock
+++ b/acceptance_test/ruby/Gemfile.lock
@@ -22,4 +22,4 @@ DEPENDENCIES
   nokogumbo
 
 BUNDLED WITH
-   1.16.1
+   2.0.1

--- a/acceptance_test/ruby/acceptance_test.rb
+++ b/acceptance_test/ruby/acceptance_test.rb
@@ -13,6 +13,10 @@ class TodoMVPAcceptance < Minitest::Test
     (0...8).map { (65 + rand(26)).chr }.join
   end
 
+  def strip_whitespace html
+    html.gsub(/\s+/, ' ')
+  end
+
   @@todo_name = random_string
 
   @@http = Faraday.new("http://localhost:3000") do |conn|
@@ -22,7 +26,7 @@ class TodoMVPAcceptance < Minitest::Test
   end
 
   def test_the_starting_page_has_the_right_html
-    assert_equal page.to_s, golden_master.to_s
+    assert_equal strip_whitespace(page.to_s), strip_whitespace(golden_master.to_s)
   end
 
   def test_adding_a_todo


### PR DESCRIPTION
Strip whitespace of starting HTML for testing so that, e.g.:

```html
<ul>

</ul>
```

 and

```html
<ul></u>
```

will both pass.

(note: I don't speak ruby! please let me know if there is a better way)